### PR TITLE
Create `cts1_make_bulk_uplink_agenda` tool for generating agendas to uplink files

### DIFF
--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -17,6 +17,10 @@ learn more about the tool.
 4. Run `uv run cts1_decode_satnogs_packets --input-csv "PATH" --output-csv "PATH"`
     * Replace the paths with your SatNOGS input data and desired output location.
 
+### Other Mission Ops Tools
+
+Refer to the `packages/cts1_mo_tools/README.md` file for a list of helpful local Mission Ops tools. For each tool, run `cts1_<tool_name> --help` to learn more about that tool.
+
 ## Development
 
 1. Complete the Getting Started section above.

--- a/packages/cts1_mo_tools/README.md
+++ b/packages/cts1_mo_tools/README.md
@@ -1,7 +1,8 @@
 # `cts1_mo_tools` - Mission Operations Tools for CTS-SAT-1
 
-Mission Operations tools that are mostly independent of the ground station (uplink and downlink) capabilities. Can run on the ground station, but mostly meant to run on local personal computers.
+Mission Operations tools that are mostly independent of the ground station capabilities (e.g., independent of uplink and downlink). Can run on the ground station, but mostly meant to run on local personal computers for planning and analysis.
 
 ## Tools
 
 * `cts1_decode_satnogs_packets`
+* `cts1_make_bulk_uplink_agenda`

--- a/packages/cts1_mo_tools/pyproject.toml
+++ b/packages/cts1_mo_tools/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 
 [project.scripts]
 cts1_decode_satnogs_packets = "cts1_mo_tools.cts1_decode_satnogs_packets:main"
+cts1_make_bulk_uplink_agenda = "cts1_mo_tools.cts1_make_bulk_uplink_agenda:main"
 
 [dependency-groups]
 dev = [

--- a/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_make_bulk_uplink_agenda.py
+++ b/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_make_bulk_uplink_agenda.py
@@ -1,0 +1,76 @@
+"""Bulk uplink a file by writing telecommands to an output file."""
+
+import base64
+import hashlib
+import sys
+from pathlib import Path
+
+import tyro
+from loguru import logger
+
+
+def send_file_to_tcmd_file(
+    input_file: Path,
+    *,
+    satellite_file: str,
+    telecommand_output_file: Path,
+    chunk_size: int = 168,
+) -> None:
+    """Send a file by writing CTS1 telecommands to an output file.
+
+    Args:
+        input_file: Path to the input file to send.
+        satellite_file: Destination filename/path on the satellite filesystem.
+        telecommand_output_file: Path to write the telecommand sequence to.
+        chunk_size: Chunk size in bytes before base64 encoding. Best if
+            divisible by 3 (and by a power of 2). Defaults to 168.
+    """
+    if not input_file.exists():
+        logger.error(f"File not found: {input_file}")
+        sys.exit(1)
+
+    lines: list[str] = []
+
+    def emit(command: str) -> None:
+        lines.append(command)
+        logger.debug(f"Emitting: {command}")
+
+    emit("CTS1+comms_bulk_uplink_close_file()")  # Safety measure.
+    emit("CTS1+config_set_int_var(TCMD_require_unique_tssent,1)")
+    emit(f"CTS1+comms_bulk_uplink_open_file({satellite_file},truncate)")
+
+    file_bytes = input_file.read_bytes()
+    total_size = len(file_bytes)
+    chunk_index = 0
+
+    logger.info(f"Encoding {input_file} ({total_size:,} bytes) into telecommands...")
+
+    offset = 0
+    while offset < total_size:
+        chunk = file_bytes[offset : offset + chunk_size]
+        b64_data = base64.b64encode(chunk).decode("ascii")
+        emit(f"CTS1+bulkup64({b64_data})")
+        offset += len(chunk)
+        chunk_index += 1
+
+    emit("CTS1+comms_bulk_uplink_close_file()")
+    emit(f"CTS1+fs_read_file_sha256_hash_json({satellite_file},0,0)")
+
+    hash_on_disk = hashlib.sha256(file_bytes).hexdigest()
+
+    # Add a comment with the hash of the input file.
+    lines.append(f"# SHA256 of input file: {hash_on_disk} ({total_size:,} bytes)")
+
+    telecommand_output_file.write_text("\n".join(lines) + "\n")
+
+    logger.success(
+        f"Wrote {len(lines)} telecommands ({chunk_index} data chunks) to "
+        f"{telecommand_output_file}"
+    )
+    logger.info(
+        f"SHA256 of input file (computer-side): {hash_on_disk} ({total_size:,} bytes)"
+    )
+
+
+if __name__ == "__main__":
+    tyro.cli(send_file_to_tcmd_file)

--- a/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_make_bulk_uplink_agenda.py
+++ b/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_make_bulk_uplink_agenda.py
@@ -66,7 +66,7 @@ def send_file_to_tcmd_file(  # noqa: PLR0913
         _parse_datetime_argument(tsexec_start_val) if tsexec_start_val else None
     )
 
-    def emit(command: str) -> None:
+    def emit(command: str, *, immediate: bool = False) -> None:
         nonlocal current_tssent, current_tsexec
 
         command_out = command.rstrip("!")
@@ -75,7 +75,7 @@ def send_file_to_tcmd_file(  # noqa: PLR0913
             tssent_int = int(current_tssent.timestamp() * 1000)
             command_out += f"@tssent={tssent_int}"
 
-        if current_tsexec is not None:
+        if current_tsexec is not None and (immediate is False):
             tsexec_int = int(current_tsexec.timestamp() * 1000)
             command_out += f"@tsexec={tsexec_int}"
 
@@ -87,11 +87,11 @@ def send_file_to_tcmd_file(  # noqa: PLR0913
         if current_tssent is not None:
             current_tssent += timedelta(milliseconds=tssent_interval_ms)
 
-        if current_tsexec is not None:
+        if current_tsexec is not None and (immediate is False):
             current_tsexec += timedelta(milliseconds=tsexec_interval_ms)
 
     emit("CTS1+comms_bulk_uplink_close_file()")  # Safety measure.
-    emit("CTS1+config_set_int_var(TCMD_require_unique_tssent,1)")
+    emit("CTS1+config_set_int_var(TCMD_require_unique_tssent,1)", immediate=True)
     emit(f"CTS1+comms_bulk_uplink_open_file({satellite_file},truncate)")
 
     file_bytes = input_file.read_bytes()

--- a/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_make_bulk_uplink_agenda.py
+++ b/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_make_bulk_uplink_agenda.py
@@ -3,18 +3,36 @@
 import base64
 import hashlib
 import sys
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import tyro
 from loguru import logger
 
 
-def send_file_to_tcmd_file(
+def _parse_datetime_argument(dt_arg: int | str) -> datetime:
+    if isinstance(dt_arg, int):
+        return datetime.fromtimestamp(dt_arg, tz=UTC)
+
+    # Else, it's a string.
+    val = datetime.fromisoformat(dt_arg)
+    if val.tzinfo is None:
+        msg = f"Please specify a timezone offset in the timestamp string: {dt_arg}"
+        raise ValueError(msg)
+
+    return val
+
+
+def send_file_to_tcmd_file(  # noqa: PLR0913
     input_file: Path,
     *,
     satellite_file: str,
     telecommand_output_file: Path,
     chunk_size: int = 168,
+    tssent_start_val: int | str | None = None,
+    tssent_interval_ms: int = 1000,
+    tsexec_start_val: int | str | None = None,
+    tsexec_interval_ms: int = 30_000,
 ) -> None:
     """Send a file by writing CTS1 telecommands to an output file.
 
@@ -24,6 +42,14 @@ def send_file_to_tcmd_file(
         telecommand_output_file: Path to write the telecommand sequence to.
         chunk_size: Chunk size in bytes before base64 encoding. Best if
             divisible by 3 (and by a power of 2). Defaults to 168.
+        tssent_start_val: Timestamp to use for the first tssent telecommand.
+            If not provided, no tssent suffix tags will be added.
+            E.g., "2027-01-01T00:00:00-06:00"
+        tssent_interval_ms: Interval in milliseconds between tssent telecommands.
+        tsexec_start_val: Timestamp to use for the first tsexec telecommand.
+            If not provided, no tsexec suffix tags will be added.
+            E.g., "2027-01-01T00:00:00-06:00"
+        tsexec_interval_ms: Interval in milliseconds between tsexec telecommands.
     """
     if not input_file.exists():
         logger.error(f"File not found: {input_file}")
@@ -31,9 +57,38 @@ def send_file_to_tcmd_file(
 
     lines: list[str] = []
 
+    current_tssent: datetime | None = (
+        _parse_datetime_argument(tssent_start_val)
+        if tssent_start_val is not None
+        else None
+    )
+    current_tsexec: datetime | None = (
+        _parse_datetime_argument(tsexec_start_val) if tsexec_start_val else None
+    )
+
     def emit(command: str) -> None:
-        lines.append(command)
-        logger.debug(f"Emitting: {command}")
+        nonlocal current_tssent, current_tsexec
+
+        command_out = command.rstrip("!")
+
+        if current_tssent is not None:
+            tssent_int = int(current_tssent.timestamp() * 1000)
+            command_out += f"@tssent={tssent_int}"
+
+        if current_tsexec is not None:
+            tsexec_int = int(current_tsexec.timestamp() * 1000)
+            command_out += f"@tsexec={tsexec_int}"
+
+        command_out += "!"
+
+        lines.append(command_out)
+        logger.debug(f"Emitting: {command_out}")
+
+        if current_tssent is not None:
+            current_tssent += timedelta(milliseconds=tssent_interval_ms)
+
+        if current_tsexec is not None:
+            current_tsexec += timedelta(milliseconds=tsexec_interval_ms)
 
     emit("CTS1+comms_bulk_uplink_close_file()")  # Safety measure.
     emit("CTS1+config_set_int_var(TCMD_require_unique_tssent,1)")

--- a/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_make_bulk_uplink_agenda.py
+++ b/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_make_bulk_uplink_agenda.py
@@ -109,12 +109,27 @@ def send_file_to_tcmd_file(  # noqa: PLR0913
         chunk_index += 1
 
     emit("CTS1+comms_bulk_uplink_close_file()")
-    emit(f"CTS1+fs_read_file_sha256_hash_json({satellite_file},0,0)")
+
+    # Repeat this 5 times for a better chance of data transfer.
+    for _ in range(5):
+        emit(f"CTS1+fs_read_file_sha256_hash_json({satellite_file},0,0)")
 
     hash_on_disk = hashlib.sha256(file_bytes).hexdigest()
 
     # Add a comment with the hash of the input file.
     lines.append(f"# SHA256 of input file: {hash_on_disk} ({total_size:,} bytes)")
+    lines.extend(
+        [
+            "# Generated with arguments:",
+            f"#   input_file.name={input_file.name}",
+            f"#   satellite_file={satellite_file}",
+            f"#   chunk_size={chunk_size}",
+            f"#   tssent_start_val={tssent_start_val}",
+            f"#   tssent_interval_ms={tssent_interval_ms}",
+            f"#   tsexec_start_val={tsexec_start_val}",
+            f"#   tsexec_interval_ms={tsexec_interval_ms}",
+        ]
+    )
 
     telecommand_output_file.write_text("\n".join(lines) + "\n")
 

--- a/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_make_bulk_uplink_agenda.py
+++ b/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_make_bulk_uplink_agenda.py
@@ -28,7 +28,7 @@ def send_file_to_tcmd_file(  # noqa: PLR0913
     *,
     satellite_file: str,
     telecommand_output_file: Path,
-    chunk_size: int = 168,
+    chunk_size: int = 96,
     tssent_start_val: int | str | None = None,
     tssent_interval_ms: int = 1000,
     tsexec_start_val: int | str | None = None,
@@ -41,7 +41,7 @@ def send_file_to_tcmd_file(  # noqa: PLR0913
         satellite_file: Destination filename/path on the satellite filesystem.
         telecommand_output_file: Path to write the telecommand sequence to.
         chunk_size: Chunk size in bytes before base64 encoding. Best if
-            divisible by 3 (and by a power of 2). Defaults to 168.
+            divisible by 3 (and by a power of 2).
         tssent_start_val: Timestamp to use for the first tssent telecommand.
             If not provided, no tssent suffix tags will be added.
             E.g., "2027-01-01T00:00:00-06:00"

--- a/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_make_bulk_uplink_agenda.py
+++ b/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_make_bulk_uplink_agenda.py
@@ -142,5 +142,9 @@ def send_file_to_tcmd_file(  # noqa: PLR0913
     )
 
 
-if __name__ == "__main__":
+def main() -> None:
     tyro.cli(send_file_to_tcmd_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This tool is used to generate an agenda which bulk uplinks a file (e.g., a blob).

It is based on the well-tested `bulk_uplink_to_devkit.py` script in the CTS-SAT-1-OBC-Firmware repository.