### PR TITLE
fetch TLE and format adcs_set_sgp4_orbit_params telecommand Script

### DIFF
--- a/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_tle_formatter.py
+++ b/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_tle_formatter.py
@@ -2,6 +2,17 @@ import requests
 from dataclasses import dataclass
 from decimal import Decimal
 
+'''
+Script to fetch FrontierSat TLE from CelesTrak, and format it into the CTS1+adcs_set_sgp4_orbit_params telecommand.
+
+To run from this file:
+1) Click the play button on the top right to run the python file
+
+To run from CLI:
+1) In the terminal, navigate to the .../CTS-SAT-1-Ground-Station/packages/cts1_mo_tools/src/cts1_mo_tools folder
+2) Run 'python cts1_tle_formatter.py'
+'''
+
 @dataclass
 class TLE:
     name: str

--- a/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_tle_formatter.py
+++ b/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_tle_formatter.py
@@ -61,16 +61,16 @@ def fetch_tle() -> str | None:
             tle_data = response.text.strip()
 
             if "No GP data found" in tle_data or not tle_data:
-                print("Error: No orbital data found for FrontierSat.") # noqa: T201
+                print("Error: No orbital data found for FrontierSat.")  # noqa: T201
                 return None
 
             return tle_data
 
-        print(f"Failed to fetch data. HTTP Status Code: {response.status_code}") # noqa: T201
-        return None # noqa: TRY300
+        print(f"Failed to fetch data. HTTP Status Code: {response.status_code}")  # noqa: T201
+        return None  # noqa: TRY300
 
     except requests.exceptions.RequestException as e:
-        print(f"An error occurred while connecting to CelesTrak: {e}") # noqa: T201
+        print(f"An error occurred while connecting to CelesTrak: {e}")  # noqa: T201
         return None
 
 
@@ -146,13 +146,14 @@ def main() -> None:
     if tle_text is None:
         return
 
-    print("\n--- TLE RETURNED FROM CELESTRAK ---") # noqa: T201
-    print(tle_text) # noqa: T201
+    print("\n--- TLE RETURNED FROM CELESTRAK ---")  # noqa: T201
+    print(tle_text)  # noqa: T201
 
     telecommand = convert_to_telecommand(tle_text)
 
-    print("\n--- FINAL FORMATTED TELECOMMAND ---") # noqa: T201
-    print(f"{telecommand}\n") # noqa: T201
+    print("\n--- FINAL FORMATTED TELECOMMAND ---")  # noqa: T201
+    print(f"{telecommand}\n")  # noqa: T201
+
 
 if __name__ == "__main__":
     main()

--- a/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_tle_formatter.py
+++ b/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_tle_formatter.py
@@ -1,0 +1,132 @@
+import requests
+from dataclasses import dataclass
+from decimal import Decimal
+
+@dataclass
+class TLE:
+    name: str
+    line1: str
+    line2: str
+
+@dataclass
+class TelecommandParams:
+    inclination: str
+    eccentricity: str
+    right_ascension: str
+    argument_of_perigee: str
+    drag_term: str
+    mean_motion: str
+    mean_anomaly: str
+    epoch: str
+
+
+def fetch_tle() -> str | None:
+    """Fetch the latest FrontierSat TLE from CelesTrak."""
+
+    url = "https://celestrak.org/NORAD/elements/gp.php"
+    params = {
+        "CATNR": "69015",
+        "FORMAT": "tle",
+    }
+
+    try:
+        response = requests.get(url, params=params)
+
+        if response.status_code == 200:
+            tle_data = response.text.strip()
+
+            if "No GP data found" in tle_data or not tle_data:
+                print("Error: No orbital data found for FrontierSat.")
+                return None
+
+            return tle_data
+
+        print(f"Failed to fetch data. HTTP Status Code: {response.status_code}")
+        return None
+
+    except requests.exceptions.RequestException as e:
+        print(f"An error occurred while connecting to CelesTrak: {e}")
+        return None
+    
+def convert_to_telecommand(tle_text: str) -> str:
+    """Convert raw TLE text into the CTS telecommand."""
+
+    tle = parse_tle(tle_text)
+    params = extract_orbit_parameters(tle)
+    return format_telecommand(params)
+
+def parse_tle(text: str) -> TLE:
+    """Parse raw TLE text into a TLE object."""
+
+    lines = text.strip().splitlines()
+
+    if len(lines) != 3:
+        raise ValueError("Expected a 3-line TLE")
+
+    return TLE(
+        name=lines[0],
+        line1=lines[1],
+        line2=lines[2],
+    )
+
+
+def extract_orbit_parameters(tle: TLE) -> TelecommandParams:
+    """Extract the orbital parameters required by the CTS telecommand."""
+
+    line1 = tle.line1.split()
+    line2 = tle.line2.split()
+
+    # Convert TLE drag term (e.g. 36581-3 -> 0.00036581)
+    initial_drag_term = (
+        Decimal("0." + line1[6][:5])
+        * (Decimal(10) ** int(line1[6][5:]))
+    )
+
+    return TelecommandParams(
+        inclination=line2[2],
+        eccentricity="0." + line2[4],
+        right_ascension=line2[3],
+        argument_of_perigee=line2[5],
+        drag_term=str(initial_drag_term.normalize()),
+        mean_motion=line2[7],
+        mean_anomaly=line2[6],
+        epoch=line1[3],
+    )
+
+
+def format_telecommand(params: TelecommandParams) -> str:
+    """Format the final CTS telecommand."""
+
+    return (
+        "CTS1+adcs_set_sgp4_orbit_params("
+        f"{params.inclination},"
+        f"{params.eccentricity},"
+        f"{params.right_ascension},"
+        f"{params.argument_of_perigee},"
+        f"{params.drag_term},"
+        f"{params.mean_motion},"
+        f"{params.mean_anomaly},"
+        f"{params.epoch}"
+        ")!"
+    )
+
+
+def main():
+    tle_text = fetch_tle()
+
+    if tle_text is None:
+        return
+
+    print("\n--- TLE RETURNED FROM CELESTRAK ---")
+    print(tle_text)
+
+    telecommand = convert_to_telecommand(tle_text)
+
+    print("\n--- FINAL FORMATTED TELECOMMAND ---")
+    print(telecommand)
+    print()
+
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_tle_formatter.py
+++ b/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_tle_formatter.py
@@ -2,7 +2,7 @@ import requests
 from dataclasses import dataclass
 from decimal import Decimal
 
-'''
+"""
 Script to fetch FrontierSat TLE from CelesTrak, and format it into the CTS1+adcs_set_sgp4_orbit_params telecommand.
 
 To run from this file:
@@ -14,13 +14,15 @@ To run from CLI:
 
 Debugging:
 If unable to run script due to 'missing requests module', then run 'uv sync'
-'''
+"""
+
 
 @dataclass
 class TLE:
     name: str
     line1: str
     line2: str
+
 
 @dataclass
 class TelecommandParams:
@@ -61,13 +63,15 @@ def fetch_tle() -> str | None:
     except requests.exceptions.RequestException as e:
         print(f"An error occurred while connecting to CelesTrak: {e}")
         return None
-    
+
+
 def convert_to_telecommand(tle_text: str) -> str:
     """Convert raw TLE text into the CTS telecommand."""
 
     tle = parse_tle(tle_text)
     params = extract_orbit_parameters(tle)
     return format_telecommand(params)
+
 
 def parse_tle(text: str) -> TLE:
     """Parse raw TLE text into a TLE object."""
@@ -91,9 +95,8 @@ def extract_orbit_parameters(tle: TLE) -> TelecommandParams:
     line2 = tle.line2.split()
 
     # Convert TLE drag term (e.g. 36581-3 -> 0.00036581)
-    initial_drag_term = (
-        Decimal("0." + line1[6][:5])
-        * (Decimal(10) ** int(line1[6][5:]))
+    initial_drag_term = Decimal("0." + line1[6][:5]) * (
+        Decimal(10) ** int(line1[6][5:])
     )
 
     return TelecommandParams(
@@ -139,7 +142,6 @@ def main():
     print("\n--- FINAL FORMATTED TELECOMMAND ---")
     print(telecommand)
     print()
-
 
 
 if __name__ == "__main__":

--- a/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_tle_formatter.py
+++ b/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_tle_formatter.py
@@ -1,15 +1,18 @@
-import requests
 from dataclasses import dataclass
 from decimal import Decimal
 
+import requests
+
 """
-Script to fetch FrontierSat TLE from CelesTrak, and format it into the CTS1+adcs_set_sgp4_orbit_params telecommand.
+Script to fetch FrontierSat TLE from CelesTrak, and format it into the
+CTS1+adcs_set_sgp4_orbit_params telecommand.
 
 To run from this file:
 1) Click the play button on the top right to run the python file
 
 To run from CLI:
-1) In the terminal, navigate to the .../CTS-SAT-1-Ground-Station/packages/cts1_mo_tools/src/cts1_mo_tools folder
+1) In the terminal, navigate to the
+.../CTS-SAT-1-Ground-Station/packages/cts1_mo_tools/src/cts1_mo_tools folder
 2) Run 'python cts1_tle_formatter.py'
 
 Debugging:
@@ -46,22 +49,28 @@ def fetch_tle() -> str | None:
     }
 
     try:
-        response = requests.get(url, params=params)
+        response = requests.get(
+            url,
+            params=params,
+            timeout=10,
+        )
 
-        if response.status_code == 200:
+        success_status_code = 200
+
+        if response.status_code == success_status_code:
             tle_data = response.text.strip()
 
             if "No GP data found" in tle_data or not tle_data:
-                print("Error: No orbital data found for FrontierSat.")
+                print("Error: No orbital data found for FrontierSat.") # noqa: T201
                 return None
 
             return tle_data
 
-        print(f"Failed to fetch data. HTTP Status Code: {response.status_code}")
-        return None
+        print(f"Failed to fetch data. HTTP Status Code: {response.status_code}") # noqa: T201
+        return None # noqa: TRY300
 
     except requests.exceptions.RequestException as e:
-        print(f"An error occurred while connecting to CelesTrak: {e}")
+        print(f"An error occurred while connecting to CelesTrak: {e}") # noqa: T201
         return None
 
 
@@ -78,8 +87,11 @@ def parse_tle(text: str) -> TLE:
 
     lines = text.strip().splitlines()
 
-    if len(lines) != 3:
-        raise ValueError("Expected a 3-line TLE")
+    expected_num_lines = 3
+
+    if len(lines) != expected_num_lines:
+        error_message = "Expected a 3-line TLE"
+        raise ValueError(error_message)
 
     return TLE(
         name=lines[0],
@@ -128,21 +140,19 @@ def format_telecommand(params: TelecommandParams) -> str:
     )
 
 
-def main():
+def main() -> None:
     tle_text = fetch_tle()
 
     if tle_text is None:
         return
 
-    print("\n--- TLE RETURNED FROM CELESTRAK ---")
-    print(tle_text)
+    print("\n--- TLE RETURNED FROM CELESTRAK ---") # noqa: T201
+    print(tle_text) # noqa: T201
 
     telecommand = convert_to_telecommand(tle_text)
 
-    print("\n--- FINAL FORMATTED TELECOMMAND ---")
-    print(telecommand)
-    print()
-
+    print("\n--- FINAL FORMATTED TELECOMMAND ---") # noqa: T201
+    print(f"{telecommand}\n") # noqa: T201
 
 if __name__ == "__main__":
     main()

--- a/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_tle_formatter.py
+++ b/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_tle_formatter.py
@@ -11,6 +11,9 @@ To run from this file:
 To run from CLI:
 1) In the terminal, navigate to the .../CTS-SAT-1-Ground-Station/packages/cts1_mo_tools/src/cts1_mo_tools folder
 2) Run 'python cts1_tle_formatter.py'
+
+Debugging:
+If unable to run script due to 'missing requests module', then run 'uv sync'
 '''
 
 @dataclass

--- a/packages/cts1_mo_tools/tests/test_tle_formatter.py
+++ b/packages/cts1_mo_tools/tests/test_tle_formatter.py
@@ -1,12 +1,12 @@
+from unittest.mock import Mock, patch
+
 import pytest
-from unittest.mock import patch, Mock
 from cts1_mo_tools.cts1_tle_formatter import (
+    TLE,
+    extract_orbit_parameters,
     fetch_tle,
     parse_tle,
-    extract_orbit_parameters,
-    TLE,
 )
-
 
 # ---------------------------------------------------------------------
 # fetch_tle() tests
@@ -15,7 +15,7 @@ from cts1_mo_tools.cts1_tle_formatter import (
 
 
 @patch("cts1_mo_tools.cts1_tle_formatter.requests.get")
-def test_fetch_tle_no_data(mock_get: Mock):
+def test_fetch_tle_no_data(mock_get: Mock) -> None:
     mock_response = Mock()
     mock_response.status_code = 200
     mock_response.text = "No GP data found"
@@ -29,7 +29,7 @@ def test_fetch_tle_no_data(mock_get: Mock):
 
 
 @patch("cts1_mo_tools.cts1_tle_formatter.requests.get")
-def test_fetch_tle_empty_response(mock_get: Mock):
+def test_fetch_tle_empty_response(mock_get: Mock) -> None:
     mock_response = Mock()
     mock_response.status_code = 200
     mock_response.text = ""
@@ -43,7 +43,7 @@ def test_fetch_tle_empty_response(mock_get: Mock):
 
 
 @patch("cts1_mo_tools.cts1_tle_formatter.requests.get")
-def test_fetch_tle_http_error(mock_get: Mock):
+def test_fetch_tle_http_error(mock_get: Mock) -> None:
     mock_response = Mock()
     mock_response.status_code = 404
 
@@ -87,7 +87,7 @@ def test_extract_orbit_parameters_converts_eccentricity() -> None:
 
 
 @pytest.mark.parametrize(
-    "drag_value, expected",
+    ("drag_value", "expected"),
     [
         ("36581-5", "0.0000036581"),
         ("36581-6", "3.6581E-7"),

--- a/packages/cts1_mo_tools/tests/test_tle_formatter.py
+++ b/packages/cts1_mo_tools/tests/test_tle_formatter.py
@@ -1,12 +1,12 @@
 import pytest
 from unittest.mock import patch, Mock
-from cts1_mo_tools.cts1_tle_formatter import fetch_tle, parse_tle
+from cts1_mo_tools.cts1_tle_formatter import fetch_tle, parse_tle, extract_orbit_parameters, TLE
 
 
 # ---------------------------------------------------------------------
 # fetch_tle() tests
 # ---------------------------------------------------------------------
-''' ("No GP data found" in tle_data) test'''
+'''Tests that "No GP data found" in tle_data is handled'''
 @patch("cts1_mo_tools.cts1_tle_formatter.requests.get")
 def test_fetch_tle_no_data(mock_get: Mock):
     mock_response = Mock()
@@ -17,7 +17,7 @@ def test_fetch_tle_no_data(mock_get: Mock):
 
     assert fetch_tle() is None
     
-'''Empty tle_data test'''
+'''Tests that empty tle_data is handled'''
 @patch("cts1_mo_tools.cts1_tle_formatter.requests.get")
 def test_fetch_tle_empty_response(mock_get: Mock):
     mock_response = Mock()
@@ -28,7 +28,7 @@ def test_fetch_tle_empty_response(mock_get: Mock):
 
     assert fetch_tle() is None
 
-'''Connection Error test'''
+'''Tests Connection Error'''
 @patch("cts1_mo_tools.cts1_tle_formatter.requests.get")
 def test_fetch_tle_http_error(mock_get: Mock):
     mock_response = Mock()
@@ -38,10 +38,11 @@ def test_fetch_tle_http_error(mock_get: Mock):
 
     assert fetch_tle() is None
     
+    
 # ---------------------------------------------------------------------
 # parse_tle(text: str) tests
 # ---------------------------------------------------------------------
-'''CelesTrak returned < 3 lines test'''
+'''Test that CelesTrak returns 3 lines'''
 def test_parse_tle_raises_error_if_not_three_lines() -> None:
     invalid_tle = (
         "FRONTIERSAT\n"
@@ -51,3 +52,41 @@ def test_parse_tle_raises_error_if_not_three_lines() -> None:
     with pytest.raises(ValueError, match="Expected a 3-line TLE"):
         parse_tle(invalid_tle)
         
+        
+# ---------------------------------------------------------------------
+# extract_orbit_parameters(tle: TLE) tests
+# --------------------------------------------------------------------- 
+'''Test that eccentricity is converted to the correct format'''
+def test_extract_orbit_parameters_converts_eccentricity() -> None:
+    tle = TLE(
+        name="TEST",
+        line1="1 69015U 24001A 25035.12345678 .00000000 00000-0 36581-5 0 9991",
+        line2="2 69015 97.5000 120.0000 0001000 180.0000 180.0000 15.00000000",
+    )
+
+    result = extract_orbit_parameters(tle)
+
+    assert result.eccentricity == "0.0001000"
+    
+'''Test that drag term is converted to the correct format'''
+@pytest.mark.parametrize(
+    "drag_value, expected",
+    [
+        ("36581-5", "0.0000036581"),
+        ("36581-6", "3.6581E-7"),
+        ("36581-1", "0.036581"),
+    ],
+)
+def test_extract_orbit_parameters_drag_term_exponents(
+    drag_value: str,
+    expected: str,
+) -> None:
+    tle = TLE(
+        name="TEST",
+        line1=f"1 69015U 24001A 25035.12345678 .00000000 00000-0 {drag_value} 0 9991",
+        line2="2 69015 97.5000 120.0000 0001000 180.0000 180.0000 15.00000000",
+    )
+
+    result = extract_orbit_parameters(tle)
+
+    assert result.drag_term == expected

--- a/packages/cts1_mo_tools/tests/test_tle_formatter.py
+++ b/packages/cts1_mo_tools/tests/test_tle_formatter.py
@@ -1,5 +1,6 @@
+import pytest
 from unittest.mock import patch, Mock
-from cts1_mo_tools.cts1_tle_formatter import fetch_tle
+from cts1_mo_tools.cts1_tle_formatter import fetch_tle, parse_tle
 
 
 # ---------------------------------------------------------------------
@@ -36,3 +37,17 @@ def test_fetch_tle_http_error(mock_get: Mock):
     mock_get.return_value = mock_response
 
     assert fetch_tle() is None
+    
+# ---------------------------------------------------------------------
+# parse_tle(text: str) tests
+# ---------------------------------------------------------------------
+'''CelesTrak returned < 3 lines test'''
+def test_parse_tle_raises_error_if_not_three_lines() -> None:
+    invalid_tle = (
+        "FRONTIERSAT\n"
+        "1 69015U 24001A"
+    )
+
+    with pytest.raises(ValueError, match="Expected a 3-line TLE"):
+        parse_tle(invalid_tle)
+        

--- a/packages/cts1_mo_tools/tests/test_tle_formatter.py
+++ b/packages/cts1_mo_tools/tests/test_tle_formatter.py
@@ -3,10 +3,30 @@ from unittest.mock import Mock, patch
 import pytest
 from cts1_mo_tools.cts1_tle_formatter import (
     TLE,
+    convert_to_telecommand,
     extract_orbit_parameters,
     fetch_tle,
     parse_tle,
 )
+
+
+def test_full_decode_and_convert_case_1() -> None:
+    """Full test from TLE to telecommand.
+
+    This is the main proof that this tool works.
+    """
+    input_tle = """
+FRONTIERSAT
+1 69015U 26100AM  26183.24927377  .00010390  00000+0  45830-3 0  9996
+2 69015  97.3985  80.8620 0007979   5.6312 354.5013 15.21937754  9113
+""".strip()
+
+    expected_output = """
+CTS1+adcs_set_sgp4_orbit_params(97.3985,0.0007979,80.8620,5.6312,0.0004583,15.21937754,354.5013,26183.24927377)!
+""".strip()
+
+    assert convert_to_telecommand(input_tle) == expected_output
+
 
 # ---------------------------------------------------------------------
 # fetch_tle() tests

--- a/packages/cts1_mo_tools/tests/test_tle_formatter.py
+++ b/packages/cts1_mo_tools/tests/test_tle_formatter.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch, Mock
+from cts1_mo_tools.cts1_tle_formatter import fetch_tle
+
+
+# ---------------------------------------------------------------------
+# fetch_tle() tests
+# ---------------------------------------------------------------------
+''' ("No GP data found" in tle_data) test'''
+@patch("cts1_mo_tools.cts1_tle_formatter.requests.get")
+def test_fetch_tle_no_data(mock_get: Mock):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.text = "No GP data found"
+
+    mock_get.return_value = mock_response
+
+    assert fetch_tle() is None
+    
+'''Empty tle_data test'''
+@patch("cts1_mo_tools.cts1_tle_formatter.requests.get")
+def test_fetch_tle_empty_response(mock_get: Mock):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.text = ""
+
+    mock_get.return_value = mock_response
+
+    assert fetch_tle() is None
+
+'''Connection Error test'''
+@patch("cts1_mo_tools.cts1_tle_formatter.requests.get")
+def test_fetch_tle_http_error(mock_get: Mock):
+    mock_response = Mock()
+    mock_response.status_code = 404
+
+    mock_get.return_value = mock_response
+
+    assert fetch_tle() is None

--- a/packages/cts1_mo_tools/tests/test_tle_formatter.py
+++ b/packages/cts1_mo_tools/tests/test_tle_formatter.py
@@ -1,12 +1,19 @@
 import pytest
 from unittest.mock import patch, Mock
-from cts1_mo_tools.cts1_tle_formatter import fetch_tle, parse_tle, extract_orbit_parameters, TLE
+from cts1_mo_tools.cts1_tle_formatter import (
+    fetch_tle,
+    parse_tle,
+    extract_orbit_parameters,
+    TLE,
+)
 
 
 # ---------------------------------------------------------------------
 # fetch_tle() tests
 # ---------------------------------------------------------------------
-'''Tests that "No GP data found" in tle_data is handled'''
+"""Tests that "No GP data found" in tle_data is handled"""
+
+
 @patch("cts1_mo_tools.cts1_tle_formatter.requests.get")
 def test_fetch_tle_no_data(mock_get: Mock):
     mock_response = Mock()
@@ -16,8 +23,11 @@ def test_fetch_tle_no_data(mock_get: Mock):
     mock_get.return_value = mock_response
 
     assert fetch_tle() is None
-    
-'''Tests that empty tle_data is handled'''
+
+
+"""Tests that empty tle_data is handled"""
+
+
 @patch("cts1_mo_tools.cts1_tle_formatter.requests.get")
 def test_fetch_tle_empty_response(mock_get: Mock):
     mock_response = Mock()
@@ -28,7 +38,10 @@ def test_fetch_tle_empty_response(mock_get: Mock):
 
     assert fetch_tle() is None
 
-'''Tests Connection Error'''
+
+"""Tests Connection Error"""
+
+
 @patch("cts1_mo_tools.cts1_tle_formatter.requests.get")
 def test_fetch_tle_http_error(mock_get: Mock):
     mock_response = Mock()
@@ -37,26 +50,27 @@ def test_fetch_tle_http_error(mock_get: Mock):
     mock_get.return_value = mock_response
 
     assert fetch_tle() is None
-    
-    
+
+
 # ---------------------------------------------------------------------
 # parse_tle(text: str) tests
 # ---------------------------------------------------------------------
-'''Test that CelesTrak returns 3 lines'''
+"""Test that CelesTrak returns 3 lines"""
+
+
 def test_parse_tle_raises_error_if_not_three_lines() -> None:
-    invalid_tle = (
-        "FRONTIERSAT\n"
-        "1 69015U 24001A"
-    )
+    invalid_tle = "FRONTIERSAT\n1 69015U 24001A"
 
     with pytest.raises(ValueError, match="Expected a 3-line TLE"):
         parse_tle(invalid_tle)
-        
-        
+
+
 # ---------------------------------------------------------------------
 # extract_orbit_parameters(tle: TLE) tests
-# --------------------------------------------------------------------- 
-'''Test that eccentricity is converted to the correct format'''
+# ---------------------------------------------------------------------
+"""Test that eccentricity is converted to the correct format"""
+
+
 def test_extract_orbit_parameters_converts_eccentricity() -> None:
     tle = TLE(
         name="TEST",
@@ -67,8 +81,11 @@ def test_extract_orbit_parameters_converts_eccentricity() -> None:
     result = extract_orbit_parameters(tle)
 
     assert result.eccentricity == "0.0001000"
-    
-'''Test that drag term is converted to the correct format'''
+
+
+"""Test that drag term is converted to the correct format"""
+
+
 @pytest.mark.parametrize(
     "drag_value, expected",
     [

--- a/packages/cts1_mo_tools/tests/test_tle_formatter.py
+++ b/packages/cts1_mo_tools/tests/test_tle_formatter.py
@@ -28,6 +28,24 @@ CTS1+adcs_set_sgp4_orbit_params(97.3985,0.0007979,80.8620,5.6312,0.0004583,15.21
     assert convert_to_telecommand(input_tle) == expected_output
 
 
+def test_full_decode_and_convert_case_2() -> None:
+    """Full test from TLE to telecommand.
+
+    This is the main proof that this tool works.
+    """
+    input_tle = """
+FRONTIERSAT
+1 69015U 26100AM  26241.68356825  .00009154  00000-0  39482-3 0  9996
+2 69015  97.3894 138.3421 0009241 135.1447 225.0538 15.22729231 18004
+""".strip()
+
+    expected_output = """
+CTS1+adcs_set_sgp4_orbit_params(97.3894,0.0009241,138.3421,135.1447,0.00039482,15.22729231,225.0538,26241.68356825)!
+""".strip()
+
+    assert convert_to_telecommand(input_tle) == expected_output
+
+
 # ---------------------------------------------------------------------
 # fetch_tle() tests
 # ---------------------------------------------------------------------


### PR DESCRIPTION
Created script for issue #39 to fetch TLE from CelesTrak and format into adcs_set_sgp4_orbit_params telecommands with the proper conversions for eccentricity and drag term. PR includes: script, tests, and inline documentation.

Example output when running from file:
<img width="1007" height="172" alt="Screenshot 2026-08-01 at 12 54 38 PM" src="https://github.com/user-attachments/assets/37a8c595-630d-460f-89b4-dd034bff4327" />

Example output when running from CLI:
<img width="869" height="159" alt="Screenshot 2026-08-01 at 1 07 36 PM" src="https://github.com/user-attachments/assets/3d73cff3-5e70-4982-b5ea-5734d8477ab6" />
