### PR TITLE
fix(decode_packets): Avoid adding CRC32 to tail of bulk_file_downlink

### DIFF
--- a/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_decode_satnogs_packets.py
+++ b/packages/cts1_mo_tools/src/cts1_mo_tools/cts1_decode_satnogs_packets.py
@@ -458,7 +458,9 @@ def verify_csp_packet_crc32c(packet: bytes) -> tuple[bool, int, int]:
 # -- Decoders -----------------------------------------------------------------
 
 
-def decode_beacon_basic_packet(payload: bytes) -> dict[str, Any]:
+def decode_beacon_basic_packet(
+    payload: bytes, _full_payload: bytes | None = None
+) -> dict[str, Any]:
     """Decode a COMMS_beacon_basic_packet_t payload (CSP header already stripped)."""
     if len(payload) < BEACON_TOTAL_STRUCT_SIZE:
         msg = (
@@ -563,7 +565,9 @@ def decode_beacon_basic_packet(payload: bytes) -> dict[str, Any]:
     return data  # noqa: RET504
 
 
-def decode_beacon_extended_packet(payload: bytes) -> dict[str, Any]:
+def decode_beacon_extended_packet(
+    payload: bytes, _full_payload: bytes | None = None
+) -> dict[str, Any]:
     """Decode a COMMS_beacon_extended_packet_t payload (CSP header already stripped).
 
     Layout: the same fixed part + friendly_message + end_message as
@@ -771,20 +775,9 @@ def decode_beacon_extended_packet(payload: bytes) -> dict[str, Any]:
     return data  # noqa: RET504
 
 
-def decode_beacon_peripheral_packet(payload: bytes) -> dict[str, Any]:
-    """Decode a COMMS_PACKET_TYPE_BEACON_PERIPHERAL payload.
-
-    No struct is defined in the header for this type yet; we surface the raw
-    bytes so the row is still tagged correctly rather than silently dropped.
-    """
-    return {
-        "packet_type": "BEACON_PERIPHERAL",
-        "raw_payload_hex": payload.hex(),
-        "_note": "BEACON_PERIPHERAL struct not yet defined; raw bytes preserved",
-    }
-
-
-def decode_log_message_packet(payload: bytes) -> dict[str, Any]:
+def decode_log_message_packet(
+    payload: bytes, _full_payload: bytes | None = None
+) -> dict[str, Any]:
     """Decode a COMMS_log_message_packet_t payload (CSP header already stripped).
 
     Layout:
@@ -818,7 +811,9 @@ def decode_log_message_packet(payload: bytes) -> dict[str, Any]:
     }
 
 
-def decode_tcmd_response_packet(payload: bytes) -> dict[str, Any]:
+def decode_tcmd_response_packet(
+    payload: bytes, _full_payload: bytes | None = None
+) -> dict[str, Any]:
     """Decode a COMMS_tcmd_response_packet_t payload (CSP header already stripped).
 
     Layout:
@@ -871,7 +866,9 @@ def decode_tcmd_response_packet(payload: bytes) -> dict[str, Any]:
     }
 
 
-def decode_bulk_file_downlink_packet(payload: bytes) -> dict[str, Any]:
+def decode_bulk_file_downlink_packet(
+    payload: bytes, full_payload: bytes
+) -> dict[str, Any]:
     """Decode a COMMS_bulk_file_downlink_packet_t payload (CSP header already stripped).
 
     Layout:
@@ -892,9 +889,15 @@ def decode_bulk_file_downlink_packet(payload: bytes) -> dict[str, Any]:
         msg = f"Unexpected packet_type byte for BULK_FILE_DOWNLINK: {packet_type:#04x}"
         raise ValueError(msg)
 
-    data_bytes = payload[
-        BULK_DOWNLINK_HEADER_SIZE : BULK_DOWNLINK_HEADER_SIZE + BULK_DOWNLINK_MAX_DATA
-    ]
+    data_bytes = payload[BULK_DOWNLINK_HEADER_SIZE:]
+
+    # If the full_payload has a CRC32C on its end, we must chop it off. Critical for the
+    # final packet in any bulk downlink series.
+    # This branch is always true in the nominal re-demodulating pipeline, but SatNOGS
+    # stations are inconsistent whether they've pre-chopped the CRC. Thus, we must
+    # check and chop here.
+    if crc32c(full_payload[:-4]) == int.from_bytes(full_payload[-4:], "big"):
+        data_bytes = data_bytes[:-4]
 
     return {
         "packet_type": "BULK_FILE_DOWNLINK",
@@ -907,7 +910,7 @@ def decode_bulk_file_downlink_packet(payload: bytes) -> dict[str, Any]:
 # Map packet_type byte → decoder function (payload = post-CSP bytes).
 _PACKET_DECODERS = {
     0x01: decode_beacon_basic_packet,
-    0x02: decode_beacon_peripheral_packet,
+    # Not implemented - 0x02
     0x03: decode_log_message_packet,
     0x04: decode_tcmd_response_packet,
     0x10: decode_bulk_file_downlink_packet,
@@ -939,7 +942,7 @@ def decode_packet_safe(hex_str: str) -> dict[str, Any] | None:
     decoder = _PACKET_DECODERS.get(packet_type_byte)
     if decoder is not None:
         try:
-            decoded = decoder(payload)
+            decoded = decoder(payload, raw)
         except (ValueError, struct.error) as exc:
             logger.warning(
                 f"Failed to decode packet type {packet_type_byte:#04x}: {exc}"

--- a/packages/cts1_mo_tools/tests/test_satnogs_decoder.py
+++ b/packages/cts1_mo_tools/tests/test_satnogs_decoder.py
@@ -24,7 +24,6 @@ from cts1_mo_tools.cts1_decode_satnogs_packets import (
     decode_adcs_current_state_1,
     decode_beacon_basic_packet,
     decode_beacon_extended_packet,
-    decode_beacon_peripheral_packet,
     decode_bulk_file_downlink_packet,
     decode_log_message_packet,
     decode_packet_safe,
@@ -392,31 +391,6 @@ class TestDecodeBeaconBasic:
 
 
 # ---------------------------------------------------------------------------
-# Tests for decode_beacon_peripheral_packet
-# ---------------------------------------------------------------------------
-
-
-class TestDecodeBeaconPeripheral:
-    def test_returns_peripheral_type(self) -> None:
-        result = decode_beacon_peripheral_packet(b"\x02\xab\xcd\xef")
-        assert result["packet_type"] == "BEACON_PERIPHERAL"
-
-    def test_raw_hex_preserved(self) -> None:
-        payload = b"\x02\x01\x02\x03"
-        result = decode_beacon_peripheral_packet(payload)
-        assert result["raw_payload_hex"] == payload.hex()
-
-    def test_note_present(self) -> None:
-        result = decode_beacon_peripheral_packet(b"\x02")
-        assert "_note" in result
-
-    def test_empty_payload(self) -> None:
-        result = decode_beacon_peripheral_packet(b"")
-        assert result["packet_type"] == "BEACON_PERIPHERAL"
-        assert result["raw_payload_hex"] == ""
-
-
-# ---------------------------------------------------------------------------
 # Tests for decode_adcs_current_state_1
 # ---------------------------------------------------------------------------
 
@@ -656,12 +630,12 @@ class TestDecodeBeaconExtended:
     def test_too_short_raises(self) -> None:
         short = b"\x20" * (BEACON_EXTENDED_TOTAL_STRUCT_SIZE - 1)
         with pytest.raises(ValueError, match="Too short"):
-            decode_beacon_extended_packet(short)
+            decode_beacon_extended_packet(short, short)
 
     def test_wrong_packet_type_raises(self) -> None:
         payload = _make_extended_payload(packet_type=0x01)
         with pytest.raises(ValueError, match="Unexpected packet_type"):
-            decode_beacon_extended_packet(payload)
+            decode_beacon_extended_packet(payload, payload)
 
     def test_total_struct_size_constant(self) -> None:
         assert len(_make_extended_payload()) == BEACON_EXTENDED_TOTAL_STRUCT_SIZE
@@ -672,7 +646,7 @@ class TestDecodeBeaconExtended:
 
     def test_extra_bytes_ignored(self) -> None:
         payload = _make_extended_payload() + b"\xff" * 10
-        result = decode_beacon_extended_packet(payload)
+        result = decode_beacon_extended_packet(payload, payload)
         assert result["packet_type"] == "BEACON_EXTENDED"
 
     def test_dispatch_via_decode_packet_safe(self) -> None:
@@ -788,7 +762,7 @@ class TestDecodeTcmdResponse:
 class TestDecodeBulkFileDownlink:
     def test_basic_fields(self) -> None:
         payload = _make_bulk_payload(file_offset=256, data=b"\x01\x02\x03\x04")
-        result = decode_bulk_file_downlink_packet(payload)
+        result = decode_bulk_file_downlink_packet(payload, payload)
         assert result["packet_type"] == "BULK_FILE_DOWNLINK"
         assert result["bulk_file_offset"] == 256
         assert result["bulk_data_len"] == 4
@@ -796,28 +770,28 @@ class TestDecodeBulkFileDownlink:
 
     def test_zero_offset(self) -> None:
         payload = _make_bulk_payload(file_offset=0)
-        result = decode_bulk_file_downlink_packet(payload)
+        result = decode_bulk_file_downlink_packet(payload, payload)
         assert result["bulk_file_offset"] == 0
 
     def test_large_offset(self) -> None:
         payload = _make_bulk_payload(file_offset=0xFFFFFFFF)
-        result = decode_bulk_file_downlink_packet(payload)
+        result = decode_bulk_file_downlink_packet(payload, payload)
         assert result["bulk_file_offset"] == 0xFFFFFFFF
 
     def test_empty_data(self) -> None:
         payload = _make_bulk_payload(data=b"")
-        result = decode_bulk_file_downlink_packet(payload)
+        result = decode_bulk_file_downlink_packet(payload, payload)
         assert result["bulk_data_len"] == 0
         assert result["bulk_data_hex"] == ""
 
     def test_too_short_raises(self) -> None:
         with pytest.raises(ValueError, match="Too short"):
-            decode_bulk_file_downlink_packet(b"\x10")
+            decode_bulk_file_downlink_packet(b"\x10", b"\x10")
 
     def test_wrong_packet_type_raises(self) -> None:
         payload = _make_bulk_payload(packet_type=0x01)
         with pytest.raises(ValueError, match="Unexpected packet_type"):
-            decode_bulk_file_downlink_packet(payload)
+            decode_bulk_file_downlink_packet(payload, payload)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
I think this may've been a decently-common occurrence when decoding data packets, caused by inconsistencies in the SatNOGS export format. Should be fixed now in this PR. 